### PR TITLE
Estimate DOA by a reduction function

### DIFF
--- a/src/PhasedArray.jl
+++ b/src/PhasedArray.jl
@@ -22,6 +22,9 @@ module PhasedArray
         calc_eigen_beamformer,
         calc_variance_covariance,
         est_doa,
+        est_doa_by_signal_subspace,
+        est_doa_by_noise_subspace,
+        est_doa_by_music,
         get_num_ants
 
     const cart2sph = SphericalFromCartesian()

--- a/src/PhasedArray.jl
+++ b/src/PhasedArray.jl
@@ -21,7 +21,7 @@ module PhasedArray
         calc_amplitude_filter,
         calc_eigen_beamformer,
         calc_variance_covariance,
-        est_doa_by_music,
+        est_doa,
         get_num_ants
 
     const cart2sph = SphericalFromCartesian()

--- a/src/est_doa.jl
+++ b/src/est_doa.jl
@@ -10,19 +10,29 @@ will use the hill climbing algorithm.
 The hill climbing algorithm should be a lot faster than plain maximum search,
 but may only find a local maximum, which might be desired.
 
+# Examples
+Using the signal subspace:
+```julia-repl
+julia> est_doa(manifold, a -> norm(signal_subspace' * a) / norm(a))
+```
+
+Using the noise subspace (MUSIC):
+```julia-repl
+julia> est_doa(manifold, a -> norm(a) / norm(noise_subspace' * a))
+```
+
 # Arguments:
-- `m::AbstractManifold{N}`: Manifold of the antenna array
-- `s::AbstractVector`: Signal subspace for which the doa is estimated
+- `manifold::AbstractManifold`: Manifold of the antenna array
+- `reduction_function`: Function that reduces the manifold vector to a scalar
 """
-function est_doa_by_music(
-    m::AbstractManifold{N},
-    s::AbstractVector;
+function est_doa(
+    manifold::AbstractManifold,
+    reduction_function;
     init_az = nothing,
     init_el = nothing,
     kwargs...
-) where N
-    length(s) == N || ArgumentError("Number of antenna channels must match")
-    p = Pattern(m, x -> abs(s' * x) / norm(x); kwargs...)
+)
+    p = Pattern(manifold, reduction_function; kwargs...)
     if isnothing(init_az) || isnothing(init_el) 
         _, idx = findmax(p.values)
     else

--- a/src/est_doa.jl
+++ b/src/est_doa.jl
@@ -48,6 +48,61 @@ end
 """
 $(SIGNATURES)
 
+This is a convenience function of `est_doa`.
+See `est_doa` for more details.
+"""
+function est_doa_by_noise_subspace(
+    manifold::AbstractManifold{N},
+    noise_subspace;
+    init_az = nothing,
+    init_el = nothing,
+    kwargs...
+) where N
+    size(noise_subspace, 1) == N || ArgumentError("Number of antenna channels must match")
+    est_doa(
+        manifold,
+        a -> norm(a) / norm(noise_subspace' * a);
+        init_az = init_az,
+        init_el = init_el,
+        kwargs...
+    )
+end
+
+"""
+$(SIGNATURES)
+
+This is a convenience function of `est_doa`.
+See `est_doa` for more details.
+"""
+function est_doa_by_signal_subspace(
+    manifold::AbstractManifold{N},
+    signal_subspace;
+    init_az = nothing,
+    init_el = nothing,
+    kwargs...
+) where N
+    size(signal_subspace, 1) == N || ArgumentError("Number of antenna channels must match")
+    est_doa(
+        manifold,
+        a -> norm(signal_subspace' * a) / norm(a);
+        init_az = init_az,
+        init_el = init_el,
+        kwargs...
+    )
+end
+
+"""
+$(SIGNATURES)
+
+This is a convenience function of `est_doa`.
+See `est_doa` for more details.
+"""
+est_doa_by_music(m, ns; init_az = nothing, init_el = nothing, k...) =
+    est_doa_by_noise_subspace(m, ns, init_az = init_az, init_el = init_el, k...)
+
+"""
+$(SIGNATURES)
+
 Multi-dimensionial hill climbing. 
 
 # Arguments:

--- a/src/est_doa.jl
+++ b/src/est_doa.jl
@@ -1,11 +1,11 @@
 """
 $(SIGNATURES)
 
-Calculate the direction of arrival of the signal `s` with respect to the 
-manifold `m`. The calculated DOA is returned as `Spherical` object, where the
+Calculate the Direction Of Arrival (DOA) with respect to the manifold
+`manifold`. The calculated DOA is returned as `Spherical` object, where the
 azimuth is counted counter-clockwise from the x axis and the elevation is
 counted from the xy-plane towards the zenith.
-If the initial azimuth `init_az` and elevation `init_el` is provided, this
+If the initial azimuth `init_az` and elevation `init_el` are provided, this
 will use the hill climbing algorithm.
 The hill climbing algorithm should be a lot faster than plain maximum search,
 but may only find a local maximum, which might be desired.

--- a/test/est_doa.jl
+++ b/test/est_doa.jl
@@ -7,22 +7,22 @@
     @test indices == CartesianIndex(158, 158)
 end
 
-@testset "Est DOA by MUSIC" begin
+@testset "Estimate DOA" begin
     ant_pos = @SMatrix([-1 1 -1 1; -1 -1 1 1; 0 0 0 0])
     manifold = IdealManifold(1, 1 / 4 * ant_pos; c0 = 1)
 
-    @test est_doa_by_music(manifold, SVector( 1,  1,  1,  1)) == Spherical(1.0, 0.0, π / 2)
-    @test est_doa_by_music(manifold, SVector( 1,  1, -1, -1)) == Spherical(1.0, π / 2, 0.0)
-    @test est_doa_by_music(manifold, SVector(-1,  1, -1,  1)) == Spherical(1.0, 0.0, 0.0)
+    @test est_doa(manifold, a -> abs(SVector( 1,  1,  1,  1)' * a) / norm(a)) == Spherical(1.0, 0.0, π / 2)
+    @test est_doa(manifold, a -> abs(SVector( 1,  1, -1, -1)' * a) / norm(a)) == Spherical(1.0, π / 2, 0.0)
+    @test est_doa(manifold, a -> abs(SVector(-1,  1, -1,  1)' * a) / norm(a)) == Spherical(1.0, 0.0, 0.0)
 
     doa = Spherical(1, 137π / 180, 40π / 180)
-    @test est_doa_by_music(manifold, get_steer_vec(manifold, doa)) == doa
+    @test est_doa(manifold, a -> abs(get_steer_vec(manifold, doa)' * a) / norm(a)) == doa
 
 
-    @test PhasedArray.sph2cart(est_doa_by_music(manifold, SVector(1, 1, 1, 1), init_az = 0.1, init_el = π / 2 - 0.1)) ≈ SVector(0, 0, 1)
-    @test est_doa_by_music(manifold, SVector( 1,  1, -1, -1), init_az = π / 2 + 0.1, init_el = 0.1) == Spherical(1.0, π / 2, 0.0)
-    @test est_doa_by_music(manifold, SVector(-1,  1, -1,  1), init_az = 0.1, init_el = 0.1) == Spherical(1.0, 0.0, 0.0)
+    @test PhasedArray.sph2cart(est_doa(manifold, a -> abs(SVector(1, 1, 1, 1)' * a) / norm(a), init_az = 0.1, init_el = π / 2 - 0.1)) ≈ SVector(0, 0, 1)
+    @test est_doa(manifold, a -> abs(SVector( 1,  1, -1, -1)' * a) / norm(a), init_az = π / 2 + 0.1, init_el = 0.1) == Spherical(1.0, π / 2, 0.0)
+    @test est_doa(manifold, a -> abs(SVector(-1,  1, -1,  1)' * a) / norm(a), init_az = 0.1, init_el = 0.1) == Spherical(1.0, 0.0, 0.0)
 
     doa = Spherical(1, 137π / 180, 40π / 180)
-    @test est_doa_by_music(manifold, get_steer_vec(manifold, doa), init_az = 137π / 180 + 0.1, init_el = 40π / 180 - 0.1) == doa
+    @test est_doa(manifold, a -> abs(get_steer_vec(manifold, doa)' * a) / norm(a), init_az = 137π / 180 + 0.1, init_el = 40π / 180 - 0.1) == doa
 end

--- a/test/est_doa.jl
+++ b/test/est_doa.jl
@@ -25,4 +25,26 @@ end
 
     doa = Spherical(1, 137π / 180, 40π / 180)
     @test est_doa(manifold, a -> abs(get_steer_vec(manifold, doa)' * a) / norm(a), init_az = 137π / 180 + 0.1, init_el = 40π / 180 - 0.1) == doa
+
+    @test est_doa_by_signal_subspace(manifold, SVector( 1,  1,  1,  1)) == Spherical(1.0, 0.0, π / 2)
+    @test est_doa_by_signal_subspace(manifold, SVector( 1,  1, -1, -1)) == Spherical(1.0, π / 2, 0.0)
+    @test est_doa_by_signal_subspace(manifold, SVector(-1,  1, -1,  1)) == Spherical(1.0, 0.0, 0.0)
+
+    doa = Spherical(1, 137π / 180, 40π / 180)
+    @test est_doa_by_signal_subspace(manifold, get_steer_vec(manifold, doa)) == doa
+
+    steer_vec = SVector( 1,  1,  1,  1)
+    noise_subspace = I - steer_vec * steer_vec' / (steer_vec' * steer_vec)
+    @test est_doa_by_noise_subspace(manifold, noise_subspace) == Spherical(1.0, 0.0, π / 2)
+    @test est_doa_by_music(manifold, noise_subspace) == Spherical(1.0, 0.0, π / 2)
+    steer_vec = SVector( 1,  1, -1, -1)
+    noise_subspace = I - steer_vec * steer_vec' / (steer_vec' * steer_vec)
+    @test est_doa_by_noise_subspace(manifold, noise_subspace) == Spherical(1.0, π / 2, 0.0)
+    @test est_doa_by_music(manifold, noise_subspace) == Spherical(1.0, π / 2, 0.0)
+
+    doa = Spherical(1, 137π / 180, 40π / 180)
+    steer_vec = get_steer_vec(manifold, doa)
+    noise_subspace = I - steer_vec * steer_vec' / (steer_vec' * steer_vec)
+    @test est_doa_by_noise_subspace(manifold, noise_subspace) == doa
+    @test est_doa_by_music(manifold, noise_subspace) == doa
 end


### PR DESCRIPTION
I needed a more general DOA estimation function. 
For example, I needed to modify the manifold steering-vector with a filter:
```
a -> abs(signal_subspace' * filter * a) / norm(filter * a)
```
The previous syntax didn't allow me to do this.
This could have been achieved with an additional parameter that defaults to `filter = I`.
However, the implemented function wasn't MUSIC by its definition anyway.
Therefore, I renamed the function to `est_doa` and instead of passing the signal subspace, it needs an reduction function.
I added some examples to make that clear.
Unfortunately, this is again a breaking change.